### PR TITLE
Bug fixing and polishing

### DIFF
--- a/src/MARIGOLD/iate.py
+++ b/src/MARIGOLD/iate.py
@@ -1,7 +1,7 @@
 from .config import *
 
 def iate(cond, query, z_step = 0.01,
-         dpdz_method = 'LM', void_method = 'driftflux', mueff_method = 'ishii', cd_method = 'doe',  # Method arguments
+         dpdz_method = 'LM', void_method = 'driftflux', mueff_method = 'ishiichawla', cd_method = 'doe',  # Method arguments
          LM_C = 40, k_m = 0.40, LoverD_restriction = 9999,                                          # Pressure drop calculation arguments
          cheat = True, elbow = False, quarantine = True):                                           # Temporary arguments, fix later
     """ Calculate the area-averaged interfacial area concentration at query location based on the 1G IATE
@@ -227,11 +227,13 @@ def iate(cond, query, z_step = 0.01,
                 ur = ure1
             ReD = rho_f * ur * Db[i] * (1 - alpha[i]) / mu_f        # Update bubble Reynolds number
             CDwe = 24 * (1 + 0.1 * ReD**0.75) / ReD                 # Update drag coefficient
+
         elif cd_method == 'doe':
             # Original DOE_MATLAB_IAC
             ReD = rho_f * ur * Db[i] * (1 - alpha[i]) / mu_f
             CDwe = 24 * (1 + 0.1 * ReD**0.75) / ReD
             ur = (4 * grav * Db[i] / 3 / CDwe)**0.5                 # Interestingly, Yadav keeps 9.8 instead of changing grav for angle
+            
         else:
             CDwe = cond.calc_cd(cd_method)
             ur = cond.calc_vr_method()
@@ -242,9 +244,9 @@ def iate(cond, query, z_step = 0.01,
         #     dissipation rate
 
         if mueff_method == 'ishii':
+            # Currently broken
+            print("Warning: Ishii method for calculating mu_eff is currently broken")
             mu_m = cond.calc_mu_eff()
-            print("mu_m: ",mu_m)
-            print("mu_m stored?: ",cond.mu_eff)
 
         elif mueff_method == 'ishiichawla':
             mu_m = mu_f / (1 - alpha[i])                        # Mixture viscosity, given by Ishii and Chawla (Eq. 4-10 in Dr. Kim thesis)

--- a/src/MARIGOLD/iate.py
+++ b/src/MARIGOLD/iate.py
@@ -244,9 +244,10 @@ def iate(cond, query, z_step = 0.01,
         if mueff_method == 'ishii':
             mu_m = cond.calc_mu_eff()
             print("mu_m: ",mu_m)
+            print("mu_m stored?: ",cond.mu_eff)
 
-        else:
-            mu_m = mu_f / (1 - alpha[i])                        # Mixture viscosity
+        elif mueff_method == 'ishiichawla':
+            mu_m = mu_f / (1 - alpha[i])                        # Mixture viscosity, given by Ishii and Chawla (Eq. 4-10 in Dr. Kim thesis)
 
         rho_m = (1 - alpha[i]) * rho_f + alpha[i] * rho_gz[i]   # Mixture density
 

--- a/src/MARIGOLD/iate.py
+++ b/src/MARIGOLD/iate.py
@@ -15,7 +15,7 @@ def iate_1d_1g(
 
         # Temporary arguments
         cheat = True, elbow = False):
-    """ Calculate the area-averaged interfacial area concentration at query location based on the 1G IATE
+    """ Calculate the area-averaged interfacial area concentration at query location based on the 1D 1G IATE
 
     Version History:
      - v1: Pressure cheating, jgref substitute for jgatm
@@ -42,9 +42,10 @@ def iate_1d_1g(
      - void_method:     Void fraction prediction method, 'driftflux' or 'continuity'
 
     Notes:
-     - IATE coefficients are currently set to default values depending on geometry
-     - Probably want to make these all optional arguments, set default values for 90 straight pipe, and input other values for different geometries outside of IATE function
-     - Same goes for COV models?
+     - Isn't this script nice and clean? Follow good coding practices, kids. - David
+     - IATE coefficients set as optional inputs, with default values set depending on geometry
+     - COV terms being implemented in Condition.py, not incorporated into this function yet
+     - vgz calculation in elbow and dissipation length regions still need to be implemented
     """
 
     # MARIGOLD retrieval
@@ -88,20 +89,31 @@ def iate_1d_1g(
     # coeff.m
 
     # Yadav
+    # Switching the logic around would make the code faster (seeing that a variable == None skips block)
+    # I like seeing all of the coefficients grouped by geometry, though
     if theta == 90 and elbow == False:
-        C_WE        = 0.002
-        C_RC        = 0.004
-        C_TI        = 0.085
+        if C_WE == None:
+            C_WE        = 0.002
+        if C_RC == None:
+            C_RC        = 0.004        
+        if C_TI == None:
+            C_TI        = 0.085
 
     elif theta == 0 and elbow == False:
-        C_WE        = 0.000
-        C_RC        = 0.003
-        C_TI        = 0.014
+        if C_WE == None:
+            C_WE        = 0.000
+        if C_RC == None:
+            C_RC        = 0.003
+        if C_TI == None:
+            C_TI        = 0.014
 
     elif elbow == True:
-        C_WE        = 0.000
-        C_RC        = 0.012
-        C_TI        = 0.085
+        if C_WE == None:
+            C_WE        = 0.000
+        if C_RC == None:
+            C_RC        = 0.012
+        if C_TI == None:
+            C_TI        = 0.085
     
     ############################################################################################################################
     #                                                                                                                          #
@@ -178,12 +190,7 @@ def iate_1d_1g(
     
     jf              = cond.jf                                   # [m/s]
     jgloc           = cond.jgloc                                # [m/s]
-
-    if 'jgatm' in dir(cond):
-        jgatm       = cond.jgatm
-    else:
-        print("Warning: jgatm not found. Defaulting to jgref")
-        jgatm       = cond.jgref
+    jgatm           = cond.jgatm                                # [m/s]
     
     # Local Pressure along the test section
     p = (jgatm * p_atm / jgloc) - p_atm                         # Back-calculate local corrected gauge pressure

--- a/src/MARIGOLD/iate.py
+++ b/src/MARIGOLD/iate.py
@@ -244,9 +244,7 @@ def iate(cond, query, z_step = 0.01,
         #     dissipation rate
 
         if mueff_method == 'ishii':
-            # Currently broken
-            print("Warning: Ishii method for calculating mu_eff is currently broken")
-            mu_m = cond.calc_mu_eff()
+            mu_m = cond.area_avg("mu_m")
 
         elif mueff_method == 'ishiichawla':
             mu_m = mu_f / (1 - alpha[i])                        # Mixture viscosity, given by Ishii and Chawla (Eq. 4-10 in Dr. Kim thesis)

--- a/src/MARIGOLD/iate.py
+++ b/src/MARIGOLD/iate.py
@@ -1,9 +1,20 @@
 from .config import *
 
-def iate(cond, query, z_step = 0.01,
-         dpdz_method = 'LM', void_method = 'driftflux', mueff_method = 'ishiichawla', cd_method = 'doe',  # Method arguments
-         LM_C = 40, k_m = 0.40, LoverD_restriction = 9999,                                          # Pressure drop calculation arguments
-         cheat = True, elbow = False, quarantine = True):                                           # Temporary arguments, fix later
+def iate_1d_1g(
+        # Basic inputs
+        cond, query, z_step,
+        
+        # IATE Coefficients
+        C_WE = None, C_RC = None, C_TI = None, alpha_max = 0.75, C = 3, We_cr = 6, acrit_flag = 0, acrit = 0.13, C0 = 1.20,
+
+        # Method arguments
+        dpdz_method = 'LM', cd_method = 'doe', void_method = 'driftflux',
+
+        # Pressure drop calculation arguments
+        LM_C = 40, k_m = 0.40, LoverD_restriction = None,
+
+        # Temporary arguments
+        cheat = True, elbow = False):
     """ Calculate the area-averaged interfacial area concentration at query location based on the 1G IATE
 
     Version History:
@@ -12,10 +23,23 @@ def iate(cond, query, z_step = 0.01,
      - v3: Yadav methods, incorporation of COV terms, support for elbows, VU, VD, horizontal
     
     Inputs:
-     - cond:             Condition object, part of MARIGOLD framework
-     - query:            L/D endpoint
-     - z_step:           Axial mesh cell size [-]
-     - void_method:      Void fraction prediction method, 'driftflux' or 'continuity'
+     - cond:            Condition object, part of MARIGOLD framework
+     - query:           L/D endpoint
+     - z_step:          Axial mesh cell size [-]
+
+     - C_WE:            Wake entrainment coefficient
+     - C_RC:            Random collision coefficient
+     - C_TI:            Turbulent impact coefficient
+     - alpha_max:       Maximum void fraction, used for random collision calculation
+     - C:               C
+     - We_cr:           Weber number criterion, used for turbulent impact calculation
+     - acrit_flag:      Enable/disable shutting off turbulence-based mechanisms beyond a critical void fraction
+     - acrit:           Critical void fraction for shutting off turbulence-based mechanisms
+     - C0:              Drift flux coefficient
+
+     - dpdz_method:     Pressure drop prediction method, 'LM' or 'Kim'
+     - cd_method:       Drag coefficient prediction method, 'iter' or 'doe'
+     - void_method:     Void fraction prediction method, 'driftflux' or 'continuity'
 
     Notes:
      - IATE coefficients are currently set to default values depending on geometry
@@ -29,14 +53,14 @@ def iate(cond, query, z_step = 0.01,
     LoverD          = cond.LoverD                               # Condition L/D
 
     # Yadav
-    RoverD = 9      # Make into optional input
+    '''
+    RoverD          = 9                                         # Make into optional input
     R_curv          = RoverD * Dh                               # Radius of curvature of elbow/bend
+    L_curv          = np.pi/2 * R_curv                          # This assumes 90\degree elbow    
 
-    # May want to include arc of the bend?
-    # Ah, yes
-    L_elb = np.pi/2 * R_curv        # This assumes 90\degree elbow
     # So, Yadav defines under Expcond.m the length of the vertical section -- I think this is how he toggles between VU, H, VD, elbow
     # Instead, we probably would want to have an input switch indicating which mode of IATE we're executing
+    '''
 
     ############################################################################################################################
     #                                                                                                                          #
@@ -62,20 +86,6 @@ def iate(cond, query, z_step = 0.01,
     #                                                                                                                          #
     ############################################################################################################################
     # coeff.m
-    
-    C_WE            = 0.002                                     # Wake entrainment coefficient, Talley
-    C_RC            = 0.004                                     # Random collision coefficient
-    C_TI            = 0.085                                     # Turbulent impact coefficient
-    
-    alpha_max       = 0.75
-    C               = 3                                         # What is this
-    We_cr           = 6                                         # Weber number criterion
-
-    acrit_flag      = 0
-    acrit           = 0.13
-    # C_WE            = 0.004                                     # Wake entrainment coefficient, Worosz
-
-    C0              = 1.20                                      # Drift Flux Model
 
     # Yadav
     if theta == 90 and elbow == False:
@@ -83,24 +93,15 @@ def iate(cond, query, z_step = 0.01,
         C_RC        = 0.004
         C_TI        = 0.085
 
-        alpha_max   = 0.75
-        C           = 3
-        We_cr       = 6
-
     elif theta == 0 and elbow == False:
+        C_WE        = 0.000
         C_RC        = 0.003
         C_TI        = 0.014
 
-        We_cr       = 5
-
     elif elbow == True:
+        C_WE        = 0.000
         C_RC        = 0.012
         C_TI        = 0.085
-
-        We_cr       = 6
-        
-        slip        = 0.91                                      # Slip at port P4 (<<vg>>/<<vf>>)
-        Const1      = 0.05                                      # Constant in the correlation for velocity
     
     ############################################################################################################################
     #                                                                                                                          #
@@ -184,11 +185,9 @@ def iate(cond, query, z_step = 0.01,
         print("Warning: jgatm not found. Defaulting to jgref")
         jgatm       = cond.jgref
     
-    p               = (jgatm * p_atm / jgloc) - p_atm           # Back-calculate local corrected gauge pressure
-
-	# Local Pressure along the test section
-    omegaz = 1 - (z_mesh - z_mesh[0]) * abs(dpdz / (p + p_atm))
-    pz = (p + p_atm) * omegaz
+    # Local Pressure along the test section
+    p = (jgatm * p_atm / jgloc) - p_atm                         # Back-calculate local corrected gauge pressure
+    pz = (p + p_atm) * (1 - (z_mesh - z_mesh[0]) * abs(dpdz / (p + p_atm)))
     
 	# Local gas density along the test section
     rho_gz = rho_g * pz / p_atm                                 # Talley
@@ -206,13 +205,12 @@ def iate(cond, query, z_step = 0.01,
             break
             
         jgloc = jgatm * p_atm / pz[i]                           # Talley used jgP1 and pressure at P1 instead of jgatm and p_atm
-
         vgz[i] = jgloc / alpha[i]                               # Estimate void weighted velocity
         vfz = jf / (1 - alpha[i])
 
         ########################################################################################################################
         # Estimate bubble relative velocity <ur> (See Talley, 2012, 4.2.2.6)
-        ur = 0.2        # Set to constant value of 0.23 m/s by Schilling (2007)
+        ur = 0.2                                                    # Set to constant value of 0.23 m/s by Schilling (2007)
 
         if cd_method == 'iter':
             err = 0.1
@@ -233,22 +231,13 @@ def iate(cond, query, z_step = 0.01,
             ReD = rho_f * ur * Db[i] * (1 - alpha[i]) / mu_f
             CDwe = 24 * (1 + 0.1 * ReD**0.75) / ReD
             ur = (4 * grav * Db[i] / 3 / CDwe)**0.5                 # Interestingly, Yadav keeps 9.8 instead of changing grav for angle
-            
-        else:
-            CDwe = cond.calc_cd(cd_method)
-            ur = cond.calc_vr_method()
 
         ########################################################################################################################
         # Estimate Energy Dissipation Rate and Turbulent Velocity (See Talley, 2012, 4.2.2.3)
         #   > One-group models written using turbulent fluctuation velocity, while models implemented in TRACE are written using
         #     dissipation rate
 
-        if mueff_method == 'ishii':
-            mu_m = cond.area_avg("mu_m")
-
-        elif mueff_method == 'ishiichawla':
-            mu_m = mu_f / (1 - alpha[i])                        # Mixture viscosity, given by Ishii and Chawla (Eq. 4-10 in Dr. Kim thesis)
-
+        mu_m = mu_f / (1 - alpha[i])                            # Mixture viscosity, given by Ishii and Chawla (Eq. 4-10 in Kim, 1999)
         rho_m = (1 - alpha[i]) * rho_f + alpha[i] * rho_gz[i]   # Mixture density
 
         vm = (rho_f * (1 - alpha[i]) * vfz + rho_gz[i] * alpha[i] * vgz[i]) \
@@ -273,24 +262,26 @@ def iate(cond, query, z_step = 0.01,
         elif elbow == True:
             SWE[i] = 0
             
-            if quarantine == False:
-                # Yadav calculates vgz differently if solving in elbow region and dissipation length region
-                '''
-                beta_diss = 0.18-7.6E-7*Rem  # dissipation coefficient
-                Sratio = 0.1; # Sratio = S/S0 (strength of elbow effect)
+            # Yadav calculates vgz differently if solving in elbow region and dissipation length region
+            '''
+            # Probably want to define these coefficients along with the COEFFICIENT block, if implemented?
+            slip = 0.91
+            Const1 = 0.05
 
-                # Elbow elbow
-                vgzP4 = slip*jf/(1-alpha[zstep_v])
-                
-                L_D = 0.3156
-                deltaz = z[i]-z[zstep_v]
-                slope = (vgzP4-vgz[zstep_v])/L_D
-                vgz[i] = vgz[zstep_v]+slope*(deltaz)
-                
-                # Dissipation elbow
-                Sratio = np.exp(-beta_diss*(z[i]-z[zstep_v+24])/Dh)
-                vgz[i] = vgzP4*(1+Const1*np.log(Sratio))
-                '''
+            beta_diss = 0.18 - 7.6E-7 * Rem     # Dissipation coefficient
+            Sratio = 0.1;                       # Sratio = S/S0 (strength of elbow effect)
+
+            # Elbow region
+            vgzP4 = slip * jf / (1 - alpha[zstep_v])            
+            L_D = 0.3156
+            deltaz = z[i] - z[zstep_v]
+            slope = (vgzP4 - vgz[zstep_v]) / L_D
+            vgz[i] = vgz[zstep_v] + slope * (deltaz)
+            
+            # Dissipation region
+            Sratio = np.exp(-beta_diss * (z[i] - z[zstep_v+24]) / Dh)
+            vgz[i] = vgzP4 * (1 + Const1 * np.log(Sratio))
+            '''
         
         # Sink due to Random Collisions	
         RC1 = ut * ai[i]**2 / alpha_max**(1/3) / (alpha_max**(1/3) - alpha[i]**(1/3))


### PR DESCRIPTION
Polished IATE script
- IATE coefficients made into optional function arguments
- Consolidated dead parts of code (Yadav's elbow code), triple-quote commented out
- Removed MG methods for calculating CD and mu_eff, since they calculate these for the condition based on port local data... Currently, CD and mu_eff update along the test section based on area-averaged projected values. If we still want to include MG methods as an option, I want to rethink where I want to put that.

To-do
- Still waiting on COV terms in Condition.py
- vgz calculation in elbow and dissipation length regions not implemented